### PR TITLE
Don't include a 'control' directory in control.tar.gz

### DIFF
--- a/lib/packager.js
+++ b/lib/packager.js
@@ -47,7 +47,7 @@ Packager.prototype.check = function () {
 
 Packager.prototype.package = function () {
     var tasks = [this.createBinary(),
-                this.makeArchive('control.tar.gz', this.opts.control),
+                this.makeArchive('control.tar.gz', this.opts.control, true),
                 this.makeArchive('data.tar.gz', this.opts.data)];
     return Promise.all(tasks).then(function (files) {
         return this.ar(this.opts.dest, files);
@@ -57,10 +57,13 @@ Packager.prototype.package = function () {
     }.bind(this));
 };
 
-Packager.prototype.makeArchive = function (name, dir) {
+Packager.prototype.makeArchive = function (name, dir, omitParent) {
     return new Promise(function (resolve, reject) {
         var outputFile = path.resolve(path.join(this.TMP_DIR, name));
         var params = ['-zcvf', outputFile];
+        if (omitParent) {
+            params.push('-C', path.resolve(dir));
+        }
         params = params.concat(fs.readdirSync(path.resolve(dir)));
         var tar = spawn('tar', params, { cwd: path.resolve(dir), stdio: ['ignore', 'ignore', 'pipe'] }),
             err = '';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "debian-packaging",
-  "version": "0.1.5",
+  "version": "0.1.5-cdm",
   "description": "Creates a .deb from a control and data directory.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
According to [the Debian docs](https://debian-handbook.info/browse/stable/packaging-system.html), `control.tar.gz` should include files at the root, not inside a `control` subdirectory.